### PR TITLE
Maintenance - Setting, Print Templates

### DIFF
--- a/modules/config.js
+++ b/modules/config.js
@@ -1171,7 +1171,7 @@ function doSavePrintTemplate(tx, world)
           {
             var datemodified = global.moment(result.rows[0].datemodified).format('YYYY-MM-DD HH:mm:ss');
 
-            resolve({datemodified: datemodified, usermodified: rwprld.cn.uname});
+            resolve({datemodified: datemodified, usermodified: world.cn.uname});
           }
           else
             reject(err);
@@ -1202,7 +1202,7 @@ function doExpirePrintTemplate(tx, world)
           {
             var dateexpired = global.moment(result.rows[0].dateexpired).format('YYYY-MM-DD HH:mm:ss');
 
-            resolve({dateexpired: dateexpired, userexpired: rwprld.cn.uname});
+            resolve({dateexpired: dateexpired, userexpired: world.cn.uname});
           }
           else
             reject(err);
@@ -1312,7 +1312,8 @@ function ListPrintTemplates(world)
           'where ' +
           'p1.customers_id=$1 ' +
           'and ' +
-          'p1.dateexpired is null',
+          'p1.dateexpired is null ' + 
+          'order by name',
           [
             world.cn.custid
           ],

--- a/routes/primushandlers.js
+++ b/routes/primushandlers.js
@@ -1381,7 +1381,8 @@ function doPrimus()
               );
             }
           );
-
+          console.log('listprinttemplates');
+          console.log(eventname);
           $('#divEvents').trigger(eventname, {data: data, pdata: $.extend(data.pdata, {})});
         }
       }

--- a/routes/tab-maintenance.js
+++ b/routes/tab-maintenance.js
@@ -162,6 +162,23 @@ function doMaintenanceTabWidgets()
       $('#divSettingsPG').propertygrid('updateRow', {index: index, row: {value: e}});
   }
 
+    // Refresh when these events occur...
+    $('#divEvents').on
+    (
+      'listprinttemplates',
+      function(ev, args)
+      {
+        if(data.length > 0)
+        {
+          data[24].editor.options.data = cache_printtemplates;
+          data[25].editor.options.data = cache_printtemplates;
+          data[26].editor.options.data = cache_printtemplates;
+          data[27].editor.options.data = cache_printtemplates;
+
+        }
+      }
+    );
+
   // Refresh when these events occur...
   $('#divEvents').on
   (


### PR DESCRIPTION
Tab-Maintenance:  Invoices, Orders, Quotes and Delivery Dockets doesn't reload cache_printtemplates properly after print templates updates. 
Tab-Print Templates: 'Save' bug, typo. 